### PR TITLE
Exception handling for "Inappropriate image size"

### DIFF
--- a/pylsd/lsd.py
+++ b/pylsd/lsd.py
@@ -10,6 +10,9 @@ from .bindings.lsd_ctypes import *
 
 def lsd(src):
     rows, cols = src.shape
+    if rows<2 or cols<2:
+        raise ValueError("Inappropriate image size")
+        
     src = src.reshape(1, rows * cols).tolist()[0]
 
     temp = os.path.abspath(str(np.random.randint(


### PR DESCRIPTION
Error : LSD Error: new_image_double: invalid image size.
in the following code, Instead of raising the error lsd close the kernel and stop the execution.
``` 
test_img = np.zeros((1,100),dtype=np.uint8)
try:
    lsd(test_img)
except Exception as e:
    print(e)
```